### PR TITLE
LUGG-1037 Add conditional to see if title is filled out

### DIFF
--- a/templates/bean--link-block.tpl.php
+++ b/templates/bean--link-block.tpl.php
@@ -7,13 +7,15 @@
       </div>
     <?php endif; ?>
 
-    <div class="link-block_label">
-      <p>
-        <?php if (isset($bean->field_link_block_label_icon['und'][0]['value'])): ?>
-          <span class="fa <?php print $bean->field_link_block_label_icon['und'][0]['value']; ?>"></span>
-        <?php endif; ?>
-        <span><?php print $title; ?></span>
-      </p>
-    </div>
+    <?php if ($bean->title !== ''): ?>
+      <div class="link-block_label">
+        <p>
+          <?php if (isset($bean->field_link_block_label_icon['und'][0]['value'])): ?>
+            <span class="fa <?php print $bean->field_link_block_label_icon['und'][0]['value']; ?>"></span>
+          <?php endif; ?>
+          <span><?php print $title; ?></span>
+        </p>
+      </div>
+    <?php endif ?>
     <?php if (isset($bean->field_link_block_url['und'][0]['url'])): ?></a><?php else: ?></div><?php endif ?>
 </div>


### PR DESCRIPTION
Bean will print the block's admin name if you don't have the title field filled. This checks that there's a real value in the title field before printing the title and related markup.