### PR TITLE
LUGG-1055 Added edit permissions for content editor

### DIFF
--- a/luggage_bean_card.features.user_permission.inc
+++ b/luggage_bean_card.features.user_permission.inc
@@ -51,6 +51,7 @@ function luggage_bean_card_user_default_permissions() {
     'name' => 'edit any card bean',
     'roles' => array(
       'bean editor' => 'bean editor',
+      'content editor' => 'content editor',
     ),
     'module' => 'bean',
   );

--- a/luggage_bean_card.info
+++ b/luggage_bean_card.info
@@ -10,6 +10,7 @@ dependencies[] = features
 dependencies[] = image
 dependencies[] = link
 dependencies[] = list
+dependencies[] = luggage_roles
 dependencies[] = options
 dependencies[] = strongarm
 features[bean_type][] = card


### PR DESCRIPTION
Changes luggage_bean_card to require luggage_roles so that we can add editing permissions for content editor.