### PR TITLE
LUGG-1056 Changed edit/delete tab text for cards

### DIFF
--- a/luggage_bean_card.module
+++ b/luggage_bean_card.module
@@ -45,3 +45,12 @@ function luggage_bean_card_preprocess_html(&$vars) {
     drupal_add_css(drupal_get_path('module', 'luggage_bean_card') . '/css/luggage_bean_card.css', array('group' => 200));
   }
 }
+
+function luggage_bean_card_menu_alter(&$items) {
+  if ($items['block/%bean_delta/edit']['title']) {
+    $items['block/%bean_delta/edit']['title'] = "Edit Card";
+  }
+  if ($items['block/%bean_delta/delete']['title']) {
+    $items['block/%bean_delta/delete']['title'] = "Delete Card";
+  }
+}


### PR DESCRIPTION
To test:
- Grab these changes
- Clear the cache a lot
- Add a card
- View the card's page. Do the edit/delete tabs say card instead of block?
- Add the card to a block region. Does the contextual link drop-down menu say card instead of block?

Also, do you see weird php errors on other block/bean pages or for anonymous users or users that can't edit beans?