### PR TITLE
LUGG-1145 Overlay style won't collapse without image.

### DIFF
--- a/css/luggage_bean_card.css
+++ b/css/luggage_bean_card.css
@@ -3,6 +3,7 @@
 /* ----------------------- */
 
 .bean-card {
+  position: relative;
   display: flex;
   justify-content: center;
   border-radius: 3px;
@@ -56,6 +57,13 @@ a.bean-card_link {
 .bean-card_dark-green .bean-card_label { background: #3E4827; }
 
 /* Overlay */
+/* Overlay needs a minimum height in case there is no image. */
+.bean-card.bean-card_dark-overlay_left,
+.bean-card.bean-card_dark-overlay_bottom {
+  min-height: 100px;
+  background: #efefef;
+}
+
 .bean-card_dark-overlay_left .bean-card_label,
 .bean-card_dark-overlay_bottom .bean-card_label {
   position: absolute;


### PR DESCRIPTION
Before, if you created a Card, chose an Overlay Style and did *not* add an image, the card would collapse and it would be difficult/impossible to find the gear to get back.

**To Test:**
1. Create a card without an image and choose Overlay. Is there a small grey background placeholder? Can you find and click the gear?
2. Does this work with both overlay left and overlay bottom?